### PR TITLE
A few last minor fixes before Big Merge

### DIFF
--- a/source/cosmetics.cpp
+++ b/source/cosmetics.cpp
@@ -6,7 +6,7 @@
 namespace Cosmetics {
 
   bool ValidHexString(std::string_view hexStr) {
-    return hexStr.find_first_not_of("0123456789ABCDEFabcdef") == std::string_view::npos;
+    return hexStr.find_first_not_of("0123456789ABCDEFabcdef") == std::string_view::npos && hexStr.length() == 6;
   }
 
   Color_RGB HexStrToColorRGB(const std::string& hexStr) {

--- a/source/preset.cpp
+++ b/source/preset.cpp
@@ -217,6 +217,12 @@ bool SaveCachedCosmetics() {
   return SavePreset("CACHED_COSMETICS", OptionCategory::Cosmetic);
 }
 
-bool LoadCachedCosmetics() {
-  return LoadPreset("CACHED_COSMETICS", OptionCategory::Cosmetic);
+void LoadCachedCosmetics() {
+  //If cache file exists, load it
+  for (const auto& entry : fs::directory_iterator(GetBasePath(OptionCategory::Cosmetic))) {
+    if(entry.path().stem().string() == "CACHED_COSMETICS") {
+      //File exists, open
+      LoadPreset("CACHED_COSMETICS", OptionCategory::Cosmetic);
+    }
+  }
 }

--- a/source/preset.hpp
+++ b/source/preset.hpp
@@ -15,4 +15,4 @@ bool SaveSpecifiedPreset(std::string_view presetName, OptionCategory category);
 void SaveCachedSettings();
 void LoadCachedSettings();
 bool SaveCachedCosmetics();
-bool LoadCachedCosmetics();
+void LoadCachedCosmetics();


### PR DESCRIPTION
- Only load cached cosmetics if the file exists for it
- Switch placement order of songs and restricted dungeon items to prevent logic lockouts
- Prevent users from typing in a custom color hex code that's too short